### PR TITLE
Add article post author fields and cover images

### DIFF
--- a/components/ArticleCard.js
+++ b/components/ArticleCard.js
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 
+const isDataUrl = (url) => typeof url === 'string' && url.startsWith('data:');
+
 export default function ArticleCard({ article, isLarge }) {
     const [hearted, setHearted] = useState(false);
 
@@ -17,12 +19,20 @@ export default function ArticleCard({ article, isLarge }) {
         <div className={`article-card p-4 border rounded-lg shadow-md relative ${isLarge ? 'large-article-card' : ''}`}>
             <Link href={`/article/${article.id}`} legacyBehavior>
                 <a>
-                    <Image src={article.image} alt={article.title} width={600} height={400} className="rounded-lg" />
+                    {isDataUrl(article.image) ? (
+                        <img src={article.image} alt={article.title} className="rounded-lg w-full h-auto" />
+                    ) : (
+                        <Image src={article.image} alt={article.title} width={600} height={400} className="rounded-lg" />
+                    )}
                     <h2 className="text-2xl font-bold mt-4">{article.title}</h2>
                 </a>
             </Link>
             <div className="flex items-center mt-2">
-                <Image src={article.authorImage} alt={article.author} width={40} height={40} className="author-image" />
+                {isDataUrl(article.authorImage) ? (
+                    <img src={article.authorImage} alt={article.author} className="author-image w-10 h-10 rounded-full" />
+                ) : (
+                    <Image src={article.authorImage} alt={article.author} width={40} height={40} className="author-image" />
+                )}
                 <div className="ml-2">
                     <p className="text-sm font-semibold">{article.author}</p>
                     <p className="text-sm text-gray-600">{article.date}</p>

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -6,6 +6,10 @@ export default function Admin() {
   const [posts, setPosts] = useState([]);
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
+  const [author, setAuthor] = useState('');
+  const [date, setDate] = useState('');
+  const [authorImage, setAuthorImage] = useState('');
+  const [image, setImage] = useState('');
   const [error, setError] = useState('');
 
   useEffect(() => {
@@ -24,19 +28,37 @@ export default function Admin() {
     }
   };
 
+  const handleFile = (file, setter) => {
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onloadend = () => setter(reader.result);
+    reader.readAsDataURL(file);
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError('');
     const res = await fetch('/api/posts', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title, content }),
+      body: JSON.stringify({
+        title,
+        content,
+        author,
+        date,
+        authorImage,
+        image,
+      }),
     });
     if (res.ok) {
       const post = await res.json();
       setPosts((p) => [...p, post]);
       setTitle('');
       setContent('');
+      setAuthor('');
+      setDate('');
+      setAuthorImage('');
+      setImage('');
     } else if (res.status === 401) {
       router.push('/login');
     } else {
@@ -60,6 +82,30 @@ export default function Admin() {
           value={content}
           onChange={(e) => setContent(e.target.value)}
           placeholder="Content"
+        />
+        <input
+          className="border p-2"
+          value={author}
+          onChange={(e) => setAuthor(e.target.value)}
+          placeholder="Author"
+        />
+        <input
+          className="border p-2"
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          type="file"
+          accept="image/*"
+          onChange={(e) => handleFile(e.target.files[0], setAuthorImage)}
+        />
+        <input
+          className="border p-2"
+          type="file"
+          accept="image/*"
+          onChange={(e) => handleFile(e.target.files[0], setImage)}
         />
         <button className="bg-blue-500 text-white p-2" type="submit">
           Save

--- a/pages/api/posts/index.js
+++ b/pages/api/posts/index.js
@@ -19,7 +19,10 @@ export default async function handler(req, res) {
 
   if (req.method === 'GET') {
     const posts = await collection.find({}).toArray();
-    const mapped = posts.map((p) => ({ ...p, id: p._id }));
+    const mapped = posts.map((p) => ({
+      ...p,
+      id: p._id.toString(),
+    }));
     return res.status(200).json(mapped);
   }
 
@@ -28,11 +31,14 @@ export default async function handler(req, res) {
     if (cookies['admin-auth'] !== 'true') {
       return res.status(401).json({ message: 'Unauthorized' });
     }
-    const { title, content } = req.body;
+    const { title, content, author, date, authorImage, image } = req.body;
     const newPost = {
       title,
       content,
-      date: new Date().toISOString(),
+      author,
+      date,
+      authorImage,
+      image,
     };
     const result = await collection.insertOne(newPost);
     newPost._id = result.insertedId;

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -4,12 +4,25 @@ import Navbar from '../../components/navbar';
 import { useArticles } from '../../context/ArticlesContext';
 import Image from 'next/image';
 import ImageCarouselCard from '../../components/ImageCarouselCard';
+import { useEffect, useState } from 'react';
 
 export default function Article() {
     const router = useRouter();
     const { id } = router.query;
     const { articles } = useArticles();
-    const article = articles.find((article) => article.id === parseInt(id));
+    const [post, setPost] = useState(null);
+    const article = articles.find((a) => String(a.id) === id);
+
+    useEffect(() => {
+        if (!article && id) {
+            fetch('/api/posts')
+                .then((res) => res.json())
+                .then((data) => {
+                    const found = data.find((p) => String(p.id) === id);
+                    if (found) setPost(found);
+                });
+        }
+    }, [article, id]);
 
     // Separate image arrays for different articles
     const imagesForArticle1 = [
@@ -24,7 +37,9 @@ export default function Article() {
         '/images/blogs/jour/3.png',
     ];
 
-    if (!article) {
+    const currentArticle = article || post;
+
+    if (!currentArticle) {
         return <p>Article not found</p>;
     }
 
@@ -35,8 +50,8 @@ export default function Article() {
     const handleShare = () => {
         if (navigator.share) {
             navigator.share({
-                title: article.title,
-                text: article.content.substring(0, 100) + '...',
+                title: currentArticle.title,
+                text: currentArticle.content.substring(0, 100) + '...',
                 url: window.location.href,
             })
                 .then(() => {
@@ -55,31 +70,31 @@ export default function Article() {
             <Navbar />
             <main className="article-page article-box">
                 <button onClick={handleBack} className="back-button">← Arrière</button>
-                <h1 className="article-title font-bold mb-4">{article.title}</h1>
+                <h1 className="article-title font-bold mb-4">{currentArticle.title}</h1>
 
                 <div className="flex items-center mb-4">
                     <Image
-                        src={article.authorImage}
-                        alt={article.author}
+                        src={currentArticle.authorImage}
+                        alt={currentArticle.author}
                         width={40}
                         height={40}
                         className="author-image"
                     />
                     <div className="ml-2">
-                        <p className="text-sm font-semibold">{article.author}</p>
-                        <p className="text-sm text-gray-600">{article.date}</p>
+                        <p className="text-sm font-semibold">{currentArticle.author}</p>
+                        <p className="text-sm text-gray-600">{currentArticle.date}</p>
                     </div>
                 </div>
 
                 <div
                     dangerouslySetInnerHTML={{
-                        __html: article.content.replace(/\n/g, '<br />'),
+                        __html: currentArticle.content.replace(/\n/g, '<br />'),
                     }}
                 />
 
                 {/* Conditionally render the carousel based on the article id */}
-                {article.id === 1 && <ImageCarouselCard images={imagesForArticle1} />}
-                {article.id === 3 && <ImageCarouselCard images={imagesForArticle3} />}
+                {currentArticle.id === 1 && <ImageCarouselCard images={imagesForArticle1} />}
+                {currentArticle.id === 3 && <ImageCarouselCard images={imagesForArticle3} />}
 
                 <button onClick={handleShare} className="share-button">
                     Partagez cet article


### PR DESCRIPTION
## Summary
- add util for checking data URLs in `ArticleCard`
- allow uploaded images for articles
- add author/date fields and file uploads in admin page
- store new fields via API
- load articles from API on the article page if not present in context

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a6dc1ec00832d89d1ff10783b1fc4