### PR TITLE
Fix admin page DB posting and ID handling

### DIFF
--- a/pages/admin.js
+++ b/pages/admin.js
@@ -21,7 +21,9 @@ export default function Admin() {
   }, []);
 
   const fetchPosts = async () => {
-    const res = await fetch('/api/posts');
+    const res = await fetch('/api/posts', {
+      credentials: 'include',
+    });
     if (res.ok) {
       const data = await res.json();
       setPosts(data);
@@ -41,6 +43,7 @@ export default function Admin() {
     const res = await fetch('/api/posts', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: JSON.stringify({
         title,
         content,

--- a/pages/api/posts/index.js
+++ b/pages/api/posts/index.js
@@ -41,8 +41,13 @@ export default async function handler(req, res) {
       image,
     };
     const result = await collection.insertOne(newPost);
-    newPost._id = result.insertedId;
-    return res.status(201).json({ ...newPost, id: newPost._id });
+    // Ensure the returned post has a string id so the frontend can use it directly
+    return res
+      .status(201)
+      .json({
+        ...newPost,
+        id: result.insertedId.toString(),
+      });
   }
 
   return res.status(405).end();


### PR DESCRIPTION
## Summary
- Send credentials with admin dashboard fetch calls so cookie-based auth reaches API routes
- Return MongoDB inserted IDs as strings to avoid ObjectId issues on the frontend

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b08bfb0464832d8f1273d53eb4563d