### PR TITLE
feat: add committee user database

### DIFF
--- a/lib/userDatabase.js
+++ b/lib/userDatabase.js
@@ -1,0 +1,11 @@
+// lib/userDatabase.js
+// Static representation of committee members.
+export const users = [
+  { name: "Kiana Salesian-Zanjani", title: "Présidente", profilePicture: "/images/Kiana.JPG" },
+  { name: "Élie Legault", title: "VP Communications", profilePicture: "/images/bbg.jpeg" },
+  { name: "Marie-Laurence Desmarais", title: "VP Affaires Externes", profilePicture: "/images/marie laurence.JPG" },
+  { name: "Negin Samadi", title: "Trésorière", profilePicture: "/images/Negin.jpg" },
+  { name: "Maweya Mbingala", title: "Secrétaire générale", profilePicture: "/images/Maweya.jpeg" },
+  { name: "Tatiana Stephan", title: "VP Évènements", profilePicture: "/images/Tatiana.jpeg" },
+  { name: "Lina Tourabi", title: "VP Première", profilePicture: "/images/lina.png" }
+];

--- a/pages/notre-comite.js
+++ b/pages/notre-comite.js
@@ -4,17 +4,7 @@ import Footer from '../components/Footer';
 import Head from "next/head";
 import React from "react";
 import SponsorsBar from "../components/Sponsors";
-
-
-const members = [
-    { name: "Kiana Salesian-Zanjani", title: "Présidente", image: "/images/Kiana.JPG" },
-    { name: "Élie Legault", title: "VP Communications", image: "/images/bbg.jpeg" },
-    { name: "Marie-Laurence Desmarais", title: "VP Affaires Externes", image: "/images/marie laurence.JPG" },
-    { name: "Negin Samadi", title: "Trésorière", image: "/images/Negin.jpg" },
-    { name: "Maweya Mbingala", title: "Secrétaire générale", image: "/images/Maweya.jpeg" },
-    { name: "Tatiana Stephan", title: "VP Évènements", image: "/images/Tatiana.jpeg" },
-    { name: "Lina Tourabi", title: "VP Première", image: "/images/lina.png" }
-];
+import { users } from "../lib/userDatabase";
 
 export default function NotreComite() {
     return (
@@ -30,22 +20,27 @@ export default function NotreComite() {
 
                 {/* Grid layout for all members except the last one (Lina Tourabi) */}
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
-                    {members.slice(0, members.length - 1).map((member, index) => (
+                    {users.slice(0, users.length - 1).map((member, index) => (
                         <div key={index} className="flex flex-col items-center text-center">
-                            <img src={member.image} alt={member.name} className="rounded-full w-64 h-32 sm:w-64 sm:h-80 lg:w-96 lg:h-96 mb-4 object-cover border-image" />
+                            <img src={member.profilePicture} alt={member.name} className="rounded-full w-64 h-32 sm:w-64 sm:h-80 lg:w-96 lg:h-96 mb-4 object-cover border-image" />
                             <h2 className="text-xl font-semibold">{member.name}</h2>
                             <p className="text-gray-600">{member.title}</p>
                         </div>
                     ))}
                 </div>
 
-                {/* Centered row for Lina Tourabi */}
+                {/* Centered row for the last member */}
                 <div className="flex justify-center mt-8">
-                    <div className="flex flex-col items-center text-center">
-                        <img src="/images/lina.png" alt="Lina Tourabi" className="rounded-full w-64 h-32 sm:w-64 sm:h-80 lg:w-96 lg:h-96 mb-4 object-cover border-image" />
-                        <h2 className="text-xl font-semibold">Lina Tourabi</h2>
-                        <p className="text-gray-600">VP Première</p>
-                    </div>
+                    {(() => {
+                        const member = users[users.length - 1];
+                        return (
+                            <div className="flex flex-col items-center text-center">
+                                <img src={member.profilePicture} alt={member.name} className="rounded-full w-64 h-32 sm:w-64 sm:h-80 lg:w-96 lg:h-96 mb-4 object-cover border-image" />
+                                <h2 className="text-xl font-semibold">{member.name}</h2>
+                                <p className="text-gray-600">{member.title}</p>
+                            </div>
+                        );
+                    })()}
                 </div>
                 <SponsorsBar />
             </main>


### PR DESCRIPTION
## Summary
- centralize committee member data in a dedicated user database
- refactor the Notre Comité page to load member details from the shared database

## Testing
- `npm test` *(fails: Missing script "test"*)
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b091a6fe6c832dbe32d0cb49210a05