### PR TITLE
Seed users collection from default data

### DIFF
--- a/pages/api/users/index.js
+++ b/pages/api/users/index.js
@@ -1,4 +1,5 @@
 import clientPromise from '../../../lib/mongodb';
+import { users as defaultUsers } from '../../../lib/userDatabase';
 
 export default async function handler(req, res) {
   const client = await clientPromise;
@@ -6,6 +7,12 @@ export default async function handler(req, res) {
   const collection = db.collection('users');
 
   if (req.method === 'GET') {
+    // Seed the database with default users if the collection is empty
+    const count = await collection.countDocuments();
+    if (count === 0) {
+      await collection.insertMany(defaultUsers);
+    }
+
     const users = await collection.find({}).toArray();
     const mapped = users.map((u) => ({
       id: u._id.toString(),


### PR DESCRIPTION
## Summary
- auto-populate the MongoDB users collection with predefined committee members when empty

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b09f572cd8832db0c32614f7e286a5