### PR TITLE
Include title in user API

### DIFF
--- a/pages/api/users/index.js
+++ b/pages/api/users/index.js
@@ -17,6 +17,7 @@ export default async function handler(req, res) {
     const mapped = users.map((u) => ({
       id: u._id.toString(),
       name: u.name,
+      title: u.title,
       profilePicture: u.profilePicture,
     }));
     return res.status(200).json(mapped);


### PR DESCRIPTION
## Summary
- Return user titles in the `/api/users` endpoint so each committee member includes picture, name, and title

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(interactive prompt prevents completion)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a3c0ae2c832d8f9c66fe6a714c6c