### PR TITLE
Remove blocking no-articles message

### DIFF
--- a/pages/blog.js
+++ b/pages/blog.js
@@ -15,10 +15,6 @@ export default function Blog() {
         setIsAdmin(document.cookie.includes('admin-auth=true'));
     }, []);
 
-    if (!articles || articles.length === 0) {
-        return <p>No articles found</p>;
-    }
-
     return (
         <div>
             <Head>

--- a/pages/index.js
+++ b/pages/index.js
@@ -10,13 +10,8 @@ import React from "react";
 
 export default function Home() {
     const { articles } = useArticles();
-    console.log('Articles:', articles); // Debugging line
 
-    if (!articles || articles.length === 0) {
-        return <p>No articles found</p>;
-    }
-
-    const topThreeArticles = articles.slice(0, 3);
+    const topThreeArticles = (articles ?? []).slice(0, 3);
 
     return (
         <div>


### PR DESCRIPTION
## Summary
- Always render home page content and recent articles section without displaying a blocking "No articles found" message
- Ensure blog page no longer short-circuits when there are zero articles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e32cb914832d9c8986e6661dd67b