### PR TITLE
feat: connect articles to database

### DIFF
--- a/context/ArticlesContext.js
+++ b/context/ArticlesContext.js
@@ -5,23 +5,24 @@ const ArticlesContext = createContext();
 export function ArticlesProvider({ children }) {
   const [articles, setArticles] = useState([]);
 
-  useEffect(() => {
-    async function load() {
-      try {
-        const res = await fetch('/api/articles');
-        if (res.ok) {
-          const data = await res.json();
-          setArticles(data);
-        }
-      } catch (err) {
-        console.error('Failed to load articles', err);
+  const refreshArticles = async () => {
+    try {
+      const res = await fetch('/api/articles');
+      if (res.ok) {
+        const data = await res.json();
+        setArticles(data);
       }
+    } catch (err) {
+      console.error('Failed to load articles', err);
     }
-    load();
+  };
+
+  useEffect(() => {
+    refreshArticles();
   }, []);
 
   return (
-    <ArticlesContext.Provider value={{ articles, setArticles }}>
+    <ArticlesContext.Provider value={{ articles, refreshArticles, setArticles }}>
       {children}
     </ArticlesContext.Provider>
   );

--- a/pages/api/articles/index.js
+++ b/pages/api/articles/index.js
@@ -1,51 +1,87 @@
 import clientPromise from '../../../lib/mongodb';
 
-function parseCookies(header) {
-  const list = {};
-  if (!header) return list;
-  header.split(';').forEach((cookie) => {
-    const [name, ...rest] = cookie.trim().split('=');
-    if (!name) return;
-    const value = rest.join('=');
-    list[decodeURIComponent(name)] = decodeURIComponent(value);
-  });
-  return list;
-}
-
 export default async function handler(req, res) {
   const client = await clientPromise;
   const db = client.db('udemdroit');
-  const collection = db.collection('articles');
 
   if (req.method === 'GET') {
-    const articles = await collection.find({}).toArray();
-    const mapped = articles.map((a) => ({
-      ...a,
-      id: a._id.toString(),
-    }));
-    return res.status(200).json(mapped);
-  }
-
-  if (req.method === 'POST') {
-    const cookies = parseCookies(req.headers.cookie || '');
-    if (cookies['admin-auth'] !== 'true') {
-      return res.status(401).json({ message: 'Unauthorized' });
+    try {
+      const articles = await db
+        .collection('articles')
+        .find({})
+        .sort({ date: -1, createdAt: -1 })
+        .toArray();
+      res.status(200).json(articles);
+    } catch (error) {
+      console.error('Failed to fetch articles:', error);
+      res.status(500).json({ error: 'Failed to fetch articles' });
     }
-    const { title, content, author, date, authorImage, image } = req.body;
-    const newArticle = {
-      title,
-      content,
-      author,
-      date,
-      authorImage,
-      image,
-    };
-    const result = await collection.insertOne(newArticle);
-    return res.status(201).json({
-      ...newArticle,
-      id: result.insertedId.toString(),
-    });
+  } else if (req.method === 'POST') {
+    try {
+      if (!req.headers.cookie?.includes('admin-auth=true')) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+      const articleData = {
+        ...req.body,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      if (!articleData.id) {
+        const lastArticle = await db
+          .collection('articles')
+          .find({})
+          .sort({ id: -1 })
+          .limit(1)
+          .toArray();
+        articleData.id = lastArticle.length > 0 ? lastArticle[0].id + 1 : 1;
+      }
+      const result = await db.collection('articles').insertOne(articleData);
+      const newArticle = { ...articleData, _id: result.insertedId };
+      res.status(201).json(newArticle);
+    } catch (error) {
+      console.error('Failed to create article:', error);
+      res.status(500).json({ error: 'Failed to create article' });
+    }
+  } else if (req.method === 'PUT') {
+    try {
+      if (!req.headers.cookie?.includes('admin-auth=true')) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+      const { id } = req.query;
+      const updates = {
+        ...req.body,
+        updatedAt: new Date(),
+      };
+      const result = await db
+        .collection('articles')
+        .updateOne({ id: parseInt(id) }, { $set: updates });
+      if (result.matchedCount === 0) {
+        return res.status(404).json({ error: 'Article not found' });
+      }
+      res.status(200).json({ message: 'Article updated successfully' });
+    } catch (error) {
+      console.error('Failed to update article:', error);
+      res.status(500).json({ error: 'Failed to update article' });
+    }
+  } else if (req.method === 'DELETE') {
+    try {
+      if (!req.headers.cookie?.includes('admin-auth=true')) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+      const { id } = req.query;
+      const result = await db
+        .collection('articles')
+        .deleteOne({ id: parseInt(id) });
+      if (result.deletedCount === 0) {
+        return res.status(404).json({ error: 'Article not found' });
+      }
+      res.status(200).json({ message: 'Article deleted successfully' });
+    } catch (error) {
+      console.error('Failed to delete article:', error);
+      res.status(500).json({ error: 'Failed to delete article' });
+    }
+  } else {
+    res.setHeader('Allow', ['GET', 'POST', 'PUT', 'DELETE']);
+    res.status(405).end(`Method ${req.method} Not Allowed`);
   }
-
-  return res.status(405).end();
 }


### PR DESCRIPTION
## Summary
- expose refreshArticles in ArticlesContext for reloading blog posts
- implement GET/POST/PUT/DELETE handlers for articles API using MongoDB and auth cookie

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: interactive prompt)

------
https://chatgpt.com/codex/tasks/task_e_68b0eb215c38832db1da86b79019856e